### PR TITLE
Changed Title

### DIFF
--- a/src/personal_setups.html
+++ b/src/personal_setups.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Linux-Ricing-Guide</title>
+        <title>Linux Ricing Guide</title>
         <link rel="stylesheet" href="style.css" />
     </head>
     <body>


### PR DESCRIPTION
This pull request includes a minor change to the `src/personal_setups.html` file. The change corrects the title format of the webpage.

* [`src/personal_setups.html`](diffhunk://#diff-63a7ab419ade31614b89d5b231497827b1f1237baaaba98d1ccf9fbad8a5fa66L6-R6): Changed the title from "Linux-Ricing-Guide" to "Linux Ricing Guide".