### PR TITLE
fixed hyperlink

### DIFF
--- a/src/distros.html
+++ b/src/distros.html
@@ -69,7 +69,7 @@
         <section>
             <h2><i class="fa-solid fa-computer"></i>Slackware</h2>
             <p>Slackware is a Linux distribution created by Patrick Volkerding in 1993. Originally based on Softlanding Linux System, Slackware has been the basis for many other Linux distributions, most notably the first versions of SUSE Linux distributions, and is the oldest distribution that is still maintained.</p>
-            <p>For more information, visit the <a href="https://slackware.com/">Slackware website</a>.</p>
+            <p>For more information, visit the <a href="http://slackware.com/">Slackware website</a>.</p>
         </section>
         <section>
             <h2><i class="fa-solid fa-computer"></i>Gentoo</h2>


### PR DESCRIPTION
This pull request includes a small change to the `src/distros.html` file. The change updates the URL for the Slackware website from "https://slackware.com/" to "http://slackware.com/".