### PR TITLE
Removed links

### DIFF
--- a/src/intro.html
+++ b/src/intro.html
@@ -2,7 +2,6 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Linux Ricing Guide</title>
         <script
             src="https://kit.fontawesome.com/0a7e2ccef9.js"
@@ -107,20 +106,6 @@
                             </tr>
                         </tbody>
                     </table>
-                </section>
-                <section>
-                    <h2><i class="fa-regular fa-star"></i>Examples</h2>
-                    <ul>
-                        <li>
-                            <a target="_blank" href="https://www.reddit.com/r/unixporn/">Reddit Unixporn</a>
-                        </li>
-                        <li>
-                            <a target="_blank" href="https://www.reddit.com/r/rice/">Reddit Ricing</a>
-                        </li>
-                    </ul>
-                    <p>
-                        or take a look at our setups <a href="setups.html">here.</a>
-                    </p>
                 </section>
             </article>
         </main>


### PR DESCRIPTION
This pull request includes changes to the `src/intro.html` file, focusing on the removal of the viewport meta tag and the deletion of the "Examples" section under the "Themes" heading.

HTML Structure Changes:

* Removed the viewport meta tag from the head section of `src/intro.html`.
* Deleted the "Examples" section, including links to Reddit Unixporn and Reddit Ricing, under the "Themes" heading in `src/intro.html`.