### PR TITLE
Fixed the scroll issue

### DIFF
--- a/src/bootstrap-style-extension.css
+++ b/src/bootstrap-style-extension.css
@@ -3,6 +3,10 @@
     scrollbar-color: #495057 #2B3035;
 }
 
+html {
+    scroll-behavior: auto !important;
+}
+
 .btn {
     border-radius: 20rem;
 }

--- a/src/distros.html
+++ b/src/distros.html
@@ -19,6 +19,7 @@
             crossorigin="anonymous"
         />
         <link rel="stylesheet" href="bootstrap-style-extension.css">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     </head>
     <body data-bs-theme="dark">
         <script

--- a/src/distros.html
+++ b/src/distros.html
@@ -18,11 +18,6 @@
             integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
             crossorigin="anonymous"
         />
-        <style>
-            html {
-                scroll-behavior: smooth;
-            }
-        </style>
         <link rel="stylesheet" href="bootstrap-style-extension.css">
     </head>
     <body data-bs-theme="dark">

--- a/src/index.html
+++ b/src/index.html
@@ -18,11 +18,6 @@
             integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
             crossorigin="anonymous"
         />
-        <style>
-            html {
-                scroll-behavior: smooth;
-            }
-        </style>
         <link rel="stylesheet" href="bootstrap-style-extension.css" />
         <script type="module" src="components/card.js"></script>
     </head>

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
         />
         <link rel="stylesheet" href="bootstrap-style-extension.css" />
         <script type="module" src="components/card.js"></script>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     </head>
     <body data-bs-theme="dark">
         <script

--- a/src/package-managers.html
+++ b/src/package-managers.html
@@ -18,11 +18,6 @@
             integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
             crossorigin="anonymous"
         />
-        <style>
-            html {
-                scroll-behavior: smooth;
-            }
-        </style>
         <link rel="stylesheet" href="bootstrap-style-extension.css" />
     </head>
     <body data-bs-theme="dark">

--- a/src/package-managers.html
+++ b/src/package-managers.html
@@ -19,6 +19,7 @@
             crossorigin="anonymous"
         />
         <link rel="stylesheet" href="bootstrap-style-extension.css" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     </head>
     <body data-bs-theme="dark">
         <script


### PR DESCRIPTION
This pull request includes changes to centralize the `scroll-behavior` CSS property and remove redundant inline styles from multiple HTML files. The most important changes include adding the `scroll-behavior` property to the `bootstrap-style-extension.css` file and removing the inline styles from the HTML files.

Centralization of CSS properties:

* [`src/bootstrap-style-extension.css`](diffhunk://#diff-f747f9d3cb9c4cff418b835dee4b24ad1c6b3ee6e627e2aee417f79cecbf6b47R6-R9): Added `scroll-behavior: auto !important;` to the `html` selector to centralize the scroll behavior styling.

Removal of redundant inline styles:

* [`src/distros.html`](diffhunk://#diff-9f45e67a591baef99f42d4fa6e0eee045f1c65c0fe889080fd0e5db8433c2998L21-L25): Removed the inline `html { scroll-behavior: smooth; }` style to rely on the centralized CSS.
* [`src/index.html`](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL21-L25): Removed the inline `html { scroll-behavior: smooth; }` style to rely on the centralized CSS.
* [`src/package-managers.html`](diffhunk://#diff-22bce5100aa25608a6c3d86da126068228b5597a9438b1abce6e8a8328873a25L21-L25): Removed the inline `html { scroll-behavior: smooth; }` style to rely on the centralized CSS.