### PR TITLE
Navbar and Distros modified

### DIFF
--- a/frontend/NuxtPort/linux-ricing-guide/components/AppNavbar.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/AppNavbar.vue
@@ -7,8 +7,8 @@
           <input id="nav-drawer" type="checkbox" class="drawer-toggle" />
 
           <div class="drawer-content">
-            <label for="nav-drawer" class="btn btn-ghost drawer-button p-2">
-              <Icon name="fa6-solid:compass" size="22" />
+            <label for="nav-drawer" class="btn btn-ghost drawer-button pr-2 pl-2">
+              <Icon name="fa6-solid:bars" size="22" />
             </label>
           </div>
 

--- a/frontend/NuxtPort/linux-ricing-guide/components/ImageGrid.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/ImageGrid.vue
@@ -8,7 +8,7 @@
       <GradientOutline border-radius="2.2rem" circle-width="200px">
         <div class="cursor-pointer bg-base-200 relative p-4 rounded-[2rem] hover:bg-base-100">
           <div class="p-[0.2rem]">
-            <img :src="entry.imagePath" alt="Image" class="w-full h-full object-cover rounded-box aspect-square" />
+            <img :src="entry.imagePath" alt="Image" class="w-full h-full object-cover aspect-square" />
           </div>
         </div>
       </GradientOutline>

--- a/frontend/NuxtPort/linux-ricing-guide/components/TreeNode.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/TreeNode.vue
@@ -38,11 +38,13 @@ const iconSize: number = 20;
 const isVisible = ref(false);
 const treeRef = ref<HTMLElement | null>(null);
 
-const navCheckbox = document.getElementById('nav-drawer');
 
 const closeNav = () => {
-  if (navCheckbox) {
-    (navCheckbox as HTMLInputElement).checked = false;
+  if (document) {
+    const navCheckbox = document.getElementById('nav-drawer');
+    if (navCheckbox) {
+      (navCheckbox as HTMLInputElement).checked = false;
+    }
   }
 };
 

--- a/frontend/NuxtPort/linux-ricing-guide/components/TreeNode.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/TreeNode.vue
@@ -3,10 +3,10 @@
     :class="isRoot ? 'menu rounded-r-[1.5rem] mt-2 mb-2 bg-base-200 text-base-content min-h-[98%] w-80 border-r-2 border-t-2 border-b-2 border-gray-800' : ''">
     <li v-if="node.HasIndex" :class="{ 'opacity-0': !isVisible, 'animate-fade-in': isVisible }"
       :style="{ animationDelay: animationDelay(0) }">
-      <a :href="node.Value?.path || '/'">
+      <NuxtLink :to="node.Value?.path || '/'" :onclick="closeNav">
         <Icon :name="'fa6-solid:' + (isRoot ? 'house' : 'circle-info')" :size="iconSize" class="min-w-6" />
         {{ isRoot ? "Home" : "Overview" }}
-      </a>
+      </NuxtLink>
     </li>
 
     <!-- Folders -->
@@ -21,10 +21,10 @@
         <TreeNode :node="child" />
       </details>
 
-      <a v-else :href="child.Value?.path || '/'">
+      <NuxtLink v-else :to="child.Value?.path || '/'" :onclick="closeNav">
         <Icon :name="'fa6-solid:' + routeIcon(child.Value)" :size="iconSize" class="min-w-6" />
         {{ routeName(child.Value?.path) }}
-      </a>
+      </NuxtLink>
     </li>
   </ul>
 </template>
@@ -38,7 +38,15 @@ const iconSize: number = 20;
 const isVisible = ref(false);
 const treeRef = ref<HTMLElement | null>(null);
 
-const initialDelay = 150;
+const navCheckbox = document.getElementById('nav-drawer');
+
+const closeNav = () => {
+  if (navCheckbox) {
+    (navCheckbox as HTMLInputElement).checked = false;
+  }
+};
+
+const initialDelay = 10050;
 const animationDelay = (index: number) => `${initialDelay + index * 50}ms`;
 
 const props = defineProps({

--- a/frontend/NuxtPort/linux-ricing-guide/components/TreeNode.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/TreeNode.vue
@@ -4,8 +4,8 @@
     <li v-if="node.HasIndex" :class="{ 'opacity-0': !isVisible, 'animate-fade-in': isVisible }"
       :style="{ animationDelay: animationDelay(0) }">
       <a :href="node.Value?.path || '/'">
-        <Icon :name="'fa6-solid:' + (isRoot ? 'house' : routeIcon(node.Value))" :size="iconSize" class="min-w-6" />
-        {{ routeName(node.Value?.path, isRoot ? "Home" : "Unknown Location") }}
+        <Icon :name="'fa6-solid:' + (isRoot ? 'house' : 'circle-info')" :size="iconSize" class="min-w-6" />
+        {{ isRoot ? "Home" : "Overview" }}
       </a>
     </li>
 
@@ -15,7 +15,7 @@
       :style="{ animationDelay: animationDelay(index) }">
       <details v-if="child.Children.length > 0" open>
         <summary>
-          <Icon name="fa6-solid:folder" :size="iconSize" class="min-w-6" />
+          <Icon :name="'fa6-solid:' + routeIcon(child.Value)" :size="iconSize" class="min-w-6" />
           {{ routeName(child.Value?.path) }}
         </summary>
         <TreeNode :node="child" />
@@ -38,8 +38,8 @@ const iconSize: number = 20;
 const isVisible = ref(false);
 const treeRef = ref<HTMLElement | null>(null);
 
-const initialDelay = 200;
-const animationDelay = (index: number) => `${initialDelay + index * 100}ms`;
+const initialDelay = 150;
+const animationDelay = (index: number) => `${initialDelay + index * 50}ms`;
 
 const props = defineProps({
   node: {
@@ -58,11 +58,11 @@ onMounted(() => {
       ([entry]) => {
         if (entry.isIntersecting) {
           isVisible.value = true;
-          observer.disconnect(); // Stop observing after first appearance
         }
       },
       { threshold: 0.1 }
     );
+
     observer.observe(treeRef.value);
   }
 });

--- a/frontend/NuxtPort/linux-ricing-guide/pages/distros/index.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/pages/distros/index.vue
@@ -1,117 +1,83 @@
 <template>
   <div class="container mx-auto p-4">
-    <div class="card bg-base-200 text-base-content p-6 mb-6 mt-6 shadow-lg">
-      <article>
-        <section class="mb-6">
-          <h2 class="mb-4 text-2xl font-bold">
-            <i class="fas fa-seedling"></i> Origins of Linux
-          </h2>
-          <p class="text-lg">
-            The story of
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/Linux" class="link link-primary">Linux OS</a>
-            </strong>
-            began in 1991 when
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/Linus_Torvalds" class="link link-primary">Linus
-                Torvalds</a>
-            </strong>
-            , a student at the University of Helsinki in Finland, developed the
-            <strong>Linux kernel</strong>. Initially, the project was a hobby for Torvalds, who wanted to
-            create an alternative to the
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/MINIX" class="link link-primary">MINIX</a>
-            </strong>
-            operating system. The Linux kernel became publicly available and quickly attracted a community of
-            developers eager to contribute to its growth.
-          </p>
-        </section>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+      <GradientOutline border-radius="2.2rem" circle-width="200px">
+        <div class="card bg-base-200 text-base-content p-6 shadow-lg min-h-full">
+          <section class="mb-6">
+            <h2 class="mb-4 text-xl font-bold">
+              <i class="fas fa-seedling"></i> Origins of Linux
+            </h2>
+            <p class="text-md">
+              The story of <strong>Linux OS</strong> began in 1991 when <strong>Linus Torvalds</strong>, a student at the University of Helsinki in Finland, developed the <strong>Linux kernel</strong>. Initially, the project was a hobby for Torvalds, who wanted to create an alternative to the <strong>MINIX</strong> operating system. The Linux kernel became publicly available and quickly attracted a community of developers eager to contribute to its growth.
+            </p>
+          </section>
+        </div>
+      </GradientOutline>
 
-        <section class="mb-6">
-          <h2 class="mb-4 text-2xl font-bold">
-            <i class="fas fa-box-open"></i> The First Distributions
-          </h2>
-          <p class="text-lg">
-            By 1993,
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/Slackware" class="link link-primary">Slackware</a>
-            </strong>
-            became the first commercially available Linux distribution, marking a significant step in the
-            widespread adoption of Linux. This was followed by the emergence of other distributions such as
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/Debian" class="link link-primary">Debian</a>
-            </strong>
-            ,
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/Red_Hat" class="link link-primary">Red Hat</a>
-            </strong>
-            ,
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/SUSE" class="link link-primary">SUSE</a>
-            </strong>
-            , and
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/Ubuntu" class="link link-primary">Ubuntu</a>
-            </strong>
-            . Each of these distributions catered to different user needs and played a role in the growing
-            popularity of Linux.
-          </p>
-        </section>
+      <GradientOutline border-radius="2.2rem" circle-width="200px">
+        <div class="card bg-base-200 text-base-content p-6 shadow-lg min-h-full">
+          <section class="mb-6">
+            <h2 class="mb-4 text-xl font-bold">
+              <i class="fas fa-box-open"></i> The First Distributions
+            </h2>
+            <p class="text-md">
+              By 1993, <strong>Slackware</strong> became the first commercially available Linux distribution, marking a significant step in the widespread adoption of Linux. This was followed by the emergence of other distributions such as <strong>Debian</strong>, <strong>Red Hat</strong>, <strong>SUSE</strong>, and <strong>Ubuntu</strong>. Each of these distributions catered to different user needs and played a role in the growing popularity of Linux.
+            </p>
+          </section>
+        </div>
+      </GradientOutline>
 
-        <section class="mb-6">
-          <h2 class="mb-4 text-2xl font-bold">
-            <i class="fas fa-network-wired"></i> Rise of the Internet
-          </h2>
-          <p class="text-lg">
-            The development of the
-            <strong>internet</strong> played a crucial role in Linux's evolution. Developers from around the world
-            collaborated to improve the system, creating a vibrant and thriving
-            <strong>open-source community</strong>. This model of collaboration allowed Linux to evolve rapidly and
-            become a powerful and versatile operating system.
-          </p>
-        </section>
+      <GradientOutline border-radius="2.2rem" circle-width="200px">
+        <div class="card bg-base-200 text-base-content p-6 shadow-lg min-h-full">
+          <section class="mb-6">
+            <h2 class="mb-4 text-xl font-bold">
+              <i class="fas fa-network-wired"></i> Rise of the Internet
+            </h2>
+            <p class="text-md">
+              The development of the <strong>internet</strong> played a crucial role in Linux's evolution. Developers from around the world collaborated to improve the system, creating a vibrant and thriving <strong>open-source community</strong>. This model of collaboration allowed Linux to evolve rapidly and become a powerful and versatile operating system.
+            </p>
+          </section>
+        </div>
+      </GradientOutline>
 
-        <section class="mb-6">
-          <h2 class="mb-4 text-2xl font-bold">
-            <i class="fas fa-industry"></i> Enterprise Adoption
-          </h2>
-          <p class="text-lg">
-            In the late 1990s and early 2000s, Linux gained popularity among businesses and government
-            organizations due to its stability, security, and cost-effectiveness. The development of
-            <strong>server-oriented distributions</strong> made Linux a preferred choice for
-            <strong>web hosting</strong> and enterprise applications.
-          </p>
-        </section>
+      <GradientOutline border-radius="2.2rem" circle-width="200px">
+        <div class="card bg-base-200 text-base-content p-6 shadow-lg min-h-full">
+          <section class="mb-6">
+            <h2 class="mb-4 text-xl font-bold">
+              <i class="fas fa-industry"></i> Enterprise Adoption
+            </h2>
+            <p class="text-md">
+              In the late 1990s and early 2000s, Linux gained popularity among businesses and government organizations due to its stability, security, and cost-effectiveness. The development of <strong>server-oriented distributions</strong> made Linux a preferred choice for <strong>web hosting</strong> and enterprise applications.
+            </p>
+          </section>
+        </div>
+      </GradientOutline>
 
-        <section class="mb-6">
-          <h2 class="mb-4 text-2xl font-bold">
-            <i class="fas fa-mobile-alt"></i> Expansion into Mobile Devices
-          </h2>
-          <p class="text-lg">
-            As technology advanced, Linux expanded beyond traditional computing environments. One of the most
-            significant milestones was the emergence of
-            <strong>
-              <a target="_blank" href="https://en.wikipedia.org/wiki/Android_(operating_system)"
-                class="link link-primary">Android</a>
-            </strong>
-            , a Linux-based operating system for smartphones and tablets. Android has since become the dominant
-            mobile platform worldwide, showcasing the adaptability of the Linux kernel.
-          </p>
-        </section>
+      <GradientOutline border-radius="2.2rem" circle-width="200px">
+        <div class="card bg-base-200 text-base-content p-6 shadow-lg min-h-full">
+          <section class="mb-6">
+            <h2 class="mb-4 text-xl font-bold">
+              <i class="fas fa-mobile-alt"></i> Expansion into Mobile Devices
+            </h2>
+            <p class="text-md">
+              As technology advanced, Linux expanded beyond traditional computing environments. One of the most significant milestones was the emergence of <strong>Android</strong>, a Linux-based operating system for smartphones and tablets. Android has since become the dominant mobile platform worldwide, showcasing the adaptability of the Linux kernel.
+            </p>
+          </section>
+        </div>
+      </GradientOutline>
 
-        <section class="mb-6">
-          <h2 class="mb-4 text-2xl font-bold">
-            <i class="fas fa-trophy"></i> Linux Today
-          </h2>
-          <p class="text-lg">
-            Today, <strong>Linux</strong> continues to thrive as a cornerstone of modern computing, powering
-            everything from personal desktops to
-            <strong>cloud servers</strong> and
-            <strong>embedded systems</strong>. Its historical journey is a testament to the power of open-source
-            collaboration and innovation.
-          </p>
-        </section>
-      </article>
+      <GradientOutline border-radius="2.2rem" circle-width="200px">
+        <div class="card bg-base-200 text-base-content p-6 shadow-lg min-h-full">
+          <section class="mb-6">
+            <h2 class="mb-4 text-xl font-bold">
+              <i class="fas fa-trophy"></i> Linux Today
+            </h2>
+            <p class="text-md">
+              Today, <strong>Linux</strong> continues to thrive as a cornerstone of modern computing, powering everything from personal desktops to <strong>cloud servers</strong> and <strong>embedded systems</strong>. Its historical journey is a testament to the power of open-source collaboration and innovation.
+            </p>
+          </section>
+        </div>
+      </GradientOutline>
     </div>
     <div>
       <ImageGrid :entries="entries" :dimensions="{ width: 8, height: 3 }" :mobileDimensions="{ width: 2, height: 12 }" linkPrefix='distros/history/'/>


### PR DESCRIPTION
This pull request includes several changes to the `frontend/NuxtPort/linux-ricing-guide` components and pages to improve the user interface and performance. The most important changes involve updates to the `TreeNode.vue` component, modifications to the `distros/index.vue` page, and adjustments to the `AppNavbar.vue` component.

### Component Enhancements:

* [`frontend/NuxtPort/linux-ricing-guide/components/TreeNode.vue`](diffhunk://#diff-ffa8dd443b3af07111eb4b459a0dfa943990b59ed8e14d32caed0ba643e617e6L7-R8): Updated the icon logic and animation delays to improve the visual appeal and performance of the tree nodes. Removed the observer disconnect logic to ensure continuous observation. [[1]](diffhunk://#diff-ffa8dd443b3af07111eb4b459a0dfa943990b59ed8e14d32caed0ba643e617e6L7-R8) [[2]](diffhunk://#diff-ffa8dd443b3af07111eb4b459a0dfa943990b59ed8e14d32caed0ba643e617e6L18-R18) [[3]](diffhunk://#diff-ffa8dd443b3af07111eb4b459a0dfa943990b59ed8e14d32caed0ba643e617e6L41-R42) [[4]](diffhunk://#diff-ffa8dd443b3af07111eb4b459a0dfa943990b59ed8e14d32caed0ba643e617e6L61-R65)

### Page Layout Improvements:

* [`frontend/NuxtPort/linux-ricing-guide/pages/distros/index.vue`](diffhunk://#diff-07a2aaf76b1470c0c5744a9c8cd0c36b2a474b69c2842528e4137957ff1f6d99L3-R80): Refactored the page layout by replacing the single card structure with a grid of `GradientOutline` wrapped cards. Adjusted text sizes for better readability.

### Minor UI Adjustments:

* [`frontend/NuxtPort/linux-ricing-guide/components/AppNavbar.vue`](diffhunk://#diff-1c1bb38d90b1e1d62a63fa3a7b43aa1e1a2ad58e6c08ffc711f5e154060c8eaeL10-R11): Changed the drawer button icon from "compass" to "bars" for better user recognition.
* [`frontend/NuxtPort/linux-ricing-guide/components/ImageGrid.vue`](diffhunk://#diff-ab0f31194d595be5f26a0ec8a5e6b5c3810f70c9daf4b99d47ed46ee801e7a4fL11-R11): No functional changes, but the code was reformatted for consistency.