### PR TITLE
Dynamic Histories Improved and Ubuntu added

### DIFF
--- a/frontend/NuxtPort/linux-ricing-guide/components/DistroHistoryTemplate.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/DistroHistoryTemplate.vue
@@ -1,7 +1,62 @@
+<template>
+  <div class="container mx-auto p-4">
+    <Motion as="div" :variants="container" initial="hidden" animate="visible"
+            class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+      <Motion :variants="items" :class="`w-full ${jsonObject.sections.length % 2 == 0 ? 'col-span-full' : ''}`">
+        <GradientOutline circle-width="200px">
+          <div class="card bg-base-200 text-base-content p-6 h-full border-primary">
+            <section class="mb-6 h-full flex flex-col">
+              <h2 class="mb-4 text-xl text-primary font-bold flex flex-row items-center">
+                <DynamicIcon :names="{ default: 'circle-info' }" class="mr-2"/> {{ jsonObject.name }}
+              </h2>
+              <p class="text-md flex-grow" v-html="jsonObject.description"></p>
+            </section>
+          </div>
+        </GradientOutline>
+      </Motion>
+      <Motion v-for="(section, index) in jsonObject.sections" :key="index" :variants="items" class="w-full">
+        <GradientOutline circle-width="200px">
+          <div class="card bg-base-200 text-base-content p-6 h-full">
+            <section class="mb-6 h-full flex flex-col">
+              <h2 class="mb-4 text-xl font-bold flex flex-row items-center">
+                <DynamicIcon :names="{ default: section.icon }" class="mr-2"/> {{ section.title }}
+              </h2>
+              <p class="text-md flex-grow" v-html="section.text"></p>
+            </section>
+          </div>
+        </GradientOutline>
+      </Motion>
+    </Motion>
+  </div>
+</template>
+
 <script setup lang="ts">
+const container = {
+  hidden: { opacity: 0, scale: 0.95 }, // Adjusted to avoid layout shift
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: {
+      type: 'spring',
+      delayChildren: 0.3, // Slightly reduced delay for smoother animation
+      staggerChildren: 0.2,
+    },
+  },
+}
+
+const items = {
+  hidden: { y: 20, opacity: 0, scale: 0.85 },
+  visible: {
+    y: 0,
+    opacity: 1,
+    scale: 1,
+  },
+}
+
 interface Section {
   title: string;
   text: string;
+  icon: string;
 }
 
 interface History {
@@ -14,12 +69,3 @@ const route = useRoute()
 const meta = route.meta;
 const jsonObject = meta.jsonObject as History;
 </script>
-
-<template>
-  <div>
-    <h1>{{ jsonObject.name }}</h1>
-  </div>
-</template>
-
-<style scoped>
-</style>

--- a/frontend/NuxtPort/linux-ricing-guide/nuxt.config.ts
+++ b/frontend/NuxtPort/linux-ricing-guide/nuxt.config.ts
@@ -45,7 +45,10 @@ export default defineNuxtConfig({
                     path: `/distros/history/${name}`,
                     file: '~/components/DistroHistoryTemplate.vue',
                     meta: {
-                        jsonObject: jsonData
+                        jsonObject: jsonData,
+                        icons: {
+                            default: 'database',
+                        }
                     }
                 })
             })

--- a/frontend/NuxtPort/linux-ricing-guide/pages/distros/index.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/pages/distros/index.vue
@@ -6,8 +6,8 @@
         <GradientOutline circle-width="200px">
           <div class="card bg-base-200 text-base-content p-6 h-full">
             <section class="mb-6 h-full flex flex-col">
-              <h2 class="mb-4 text-xl font-bold">
-                <DynamicIcon :names="{ default: section.icon }" /> {{ section.title }}
+              <h2 class="mb-4 text-xl font-bold flex flex-row items-center">
+                <DynamicIcon :names="{ default: section.icon }" class="mr-2"/> {{ section.title }}
               </h2>
               <p class="text-md flex-grow" v-html="section.content"></p>
             </section>
@@ -59,99 +59,99 @@ type entry = {
 
 const entries: entry[] = [{
   imagePath: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Flogos-marcas.com%2Fwp-content%2Fuploads%2F2020%2F11%2FUbuntu-Emblema.png&f=1&nofb=1&ipt=9131eaa826134a968cf6350785fe0819a49120ed17985e272f01b0b51452798a&ipo=images',
-  link: 'ubuntu-history'
+  link: 'ubuntu'
 },
 {
   imagePath: 'https://logodix.com/logo/1171807.png',
-  link: 'debian-history'
+  link: 'debian'
 },
 {
   imagePath: 'https://wiki.installgentoo.com/images/f/f9/Arch-linux-logo.png',
-  link: 'arch-history'
+  link: 'arch'
 },
 {
   imagePath: 'https://logodix.com/logo/675587.png',
-  link: 'manjaro-history'
+  link: 'manjaro'
 },
 {
   imagePath: 'https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.lffl.org%2Fwp-content%2Fuploads%2F2020%2F05%2FPop_OS-20.04-1.png&f=1&nofb=1&ipt=b9813ad2b5d562eee2fa401a5fa3a2fba04b11fa74b48a883bc0148c854b6a6a&ipo=images',
-  link: 'pop!-os-history'
+  link: 'pop!-os'
 },
 {
   imagePath: 'https://2.bp.blogspot.com/-oLPLjT8GMG0/WjKrRPTm2CI/AAAAAAAADRA/evQEjsmF_nMtCJp5xaAKWJqHsjYOxL0bgCLcBGAs/s1600/Linux_Mint_logo_without_wordmark.svg.png',
-  link: 'mint-history'
+  link: 'mint'
 },
 {
   imagePath: 'https://s3.amazonaws.com/media-p.slid.es/uploads/183933/images/1332684/elementary_logo.png',
-  link: 'elementary-os-history'
+  link: 'elementary-os'
 },
 {
   imagePath: 'https://logospng.org/download/centos/centos-logo-1024.png',
-  link: 'cent-os-history'
+  link: 'cent-os'
 },
 {
   imagePath: 'https://juststickers.in/wp-content/uploads/2019/07/fedora.png',
-  link: 'fedora-history'
+  link: 'fedora'
 },
 {
   imagePath: 'https://www.kindpng.com/picc/m/97-975947_void-linux-logo-png-transparent-png.png',
-  link: 'void-linux-history'
+  link: 'void-linux'
 },
 {
   imagePath: 'https://cdn0.iconfinder.com/data/icons/flat-round-system/512/opensuse-512.png',
-  link: 'openSUSE-history'
+  link: 'openSUSE'
 },
 {
   imagePath: 'https://www.qubes-os.org/attachment/icons/512x512/apps/qubes-logo-icon.png',
-  link: 'qubes-os-history'
+  link: 'qubes-os'
 },
 {
   imagePath: 'https://freesvg.org/img/1634281368Slackware_logo.png',
-  link: 'slackware-history'
+  link: 'slackware'
 },
 {
   imagePath: 'https://freepngimg.com/thumb/ubuntu/62619-vector-gentoo-icons-graphics-scalable-computer-linux.png',
-  link: 'gentoo-history'
+  link: 'gentoo'
 },
 {
   imagePath: 'https://pingvinus.ru/cr_images/modelImage/application/3384-logo-n9h2eb9.png',
-  link: 'alpine-linux-history'
+  link: 'alpine-linux'
 },
 {
   imagePath: 'https://freesvg.org/img/1634268452MX_Linux_logo.png',
-  link: 'mx-linux-history'
+  link: 'mx-linux'
 },
 {
   imagePath: 'https://cdn.pixabay.com/photo/2013/03/30/00/09/operating-system-97851_1280.png',
-  link: 'ubuntu-studio-history'
+  link: 'ubuntu-studio'
 },
 {
   imagePath: 'https://www.edureka.co/blog/wp-content/uploads/2019/02/parrot-logo-kali-vs-parrot-edureka.png',
-  link: 'parrot-security-os-history'
+  link: 'parrot-security-os'
 },
 {
   imagePath: 'https://www.freelogovectors.net/wp-content/uploads/2021/12/kali-logo-freelogovectors.net_.png',
-  link: 'kali-linux-history'
+  link: 'kali-linux'
 },
 {
   imagePath: 'https://seekicon.com/free-icon-download/arch-linux_1.png',
-  link: 'black-arch-linux-history'
+  link: 'black-arch-linux'
 },
 {
   imagePath: 'https://images.seeklogo.com/logo-png/44/1/artix-linux-logo-png_seeklogo-448539.png',
-  link: 'artix-linux-history'
+  link: 'artix-linux'
 },
 {
   imagePath: 'https://endeavouros.com/wp-content/uploads/2019/08/EndeavourOS-logo.png',
-  link: 'endeavour-os-history'
+  link: 'endeavour-os'
 },
 {
   imagePath: 'https://www.nesabamedia.com/wp-content/uploads/2022/11/Garuda-Linux-Logo-1.png',
-  link: 'garuda-linux-history'
+  link: 'garuda-linux'
 },
 {
   imagePath: 'https://lignux.com/wp-content/uploads/2013/08/trisquel.jpg',
-  link: 'trisquel-history'
+  link: 'trisquel'
 }
 ];
 

--- a/frontend/NuxtPort/linux-ricing-guide/server-data/histories/debian.json
+++ b/frontend/NuxtPort/linux-ricing-guide/server-data/histories/debian.json
@@ -4,14 +4,17 @@
   "sections": [
     {
       "title": "Early Years",
+      "icon": "clock-rotate-left",
       "text": "In the early years, Debian was a small project with a few developers. Over time, it grew in size and scope, attracting more developers and users."
     },
     {
       "title": "Growth and Development",
+      "icon": "code",
       "text": "As Debian grew, it became known for its stability and reliability. The project introduced many innovations, such as the Advanced Packaging Tool (APT) and the Debian Social Contract."
     },
     {
       "title": "Current Status",
+      "icon": "calendar",
       "text": "Today, Debian is used by millions of people around the world. It serves as the basis for many other distributions, including Ubuntu, one of the most popular Linux distributions."
     }
   ]

--- a/frontend/NuxtPort/linux-ricing-guide/server-data/histories/ubuntu.json
+++ b/frontend/NuxtPort/linux-ricing-guide/server-data/histories/ubuntu.json
@@ -1,0 +1,26 @@
+{
+  "name": "Ubuntu",
+  "description": "Ubuntu was first released in October 2004. It was created by Mark Shuttleworth and his company Canonical Ltd. The goal was to create an easy-to-use Linux distribution with a regular release cycle.",
+  "sections": [
+    {
+      "title": "Features",
+      "icon": "list",
+      "text": "Ubuntu includes a wide range of software, including the LibreOffice suite, the Firefox web browser, and the Thunderbird email client. It also features a custom desktop environment called Unity."
+    },
+    {
+      "title": "Release Cycle",
+      "icon": "calendar",
+      "text": "Ubuntu has a regular release cycle, with new versions released every six months. Every two years, a Long Term Support (LTS) version is released, which is supported for five years."
+    },
+    {
+      "title": "Community",
+      "icon": "users",
+      "text": "Ubuntu has a large and active community of users and developers. The community contributes to the development of the distribution, provides support, and creates documentation."
+    },
+    {
+      "title": "Current Status",
+      "icon": "chart-line",
+      "text": "Today, Ubuntu is one of the most popular Linux distributions. It is used by millions of people around the world, from personal desktops to servers and cloud computing."
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces several changes to enhance the `DistroHistoryTemplate` component and related files in the `frontend/NuxtPort/linux-ricing-guide` directory. The changes include the addition of new template structures, animations, and icon support for better user experience and visual appeal.

### Enhancements to `DistroHistoryTemplate` component:

* Added a new template structure with a responsive grid layout and animated sections for displaying distribution history. (`frontend/NuxtPort/linux-ricing-guide/components/DistroHistoryTemplate.vue`)
* Introduced motion animations for the container and items to create a smoother user experience. (`frontend/NuxtPort/linux-ricing-guide/components/DistroHistoryTemplate.vue`)

### Icon and Metadata Improvements:

* Updated the `nuxt.config.ts` to include default icons in the metadata for history pages. (`frontend/NuxtPort/linux-ricing-guide/nuxt.config.ts`)
* Added icons to the sections of the Debian and Ubuntu history JSON files to visually represent different sections. (`frontend/NuxtPort/linux-ricing-guide/server-data/histories/debian.json`, `frontend/NuxtPort/linux-ricing-guide/server-data/histories/ubuntu.json`) [[1]](diffhunk://#diff-e2cbd8209f4aa5923d7ad303aa64c3f62f98fc0fb99c9724ca41f1a32623a07cR7-R17) [[2]](diffhunk://#diff-0e7c5810c4ac20b3839b92f1dace987f4d57093a9491826d8d47cf1234dae6daR1-R26)

### Consistency and Cleanup:

* Removed the old template and style block from `DistroHistoryTemplate.vue` to clean up the codebase. (`frontend/NuxtPort/linux-ricing-guide/components/DistroHistoryTemplate.vue`)
* Updated link paths in `distros/index.vue` to ensure consistency and remove the `-history` suffix. (`frontend/NuxtPort/linux-ricing-guide/pages/distros/index.vue`)