### PR TITLE
Loading Indicator Updated

### DIFF
--- a/frontend/NuxtPort/linux-ricing-guide/components/AppNavbar.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/AppNavbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="navbar bg-opacity-70 backdrop-blur-md border-b-2 border-base-300 sticky top-0 z-50"
+  <div class="navbar bg-opacity-70 backdrop-blur-md border-b-2 border-base-300 sticky top-0 z-50 h-16"
     style="background-color: rgba(var(--bg-base-200), 0.69)">
 
     <div class="flex-1 flex items-center text-neutral-content">
@@ -51,6 +51,8 @@
       <ThemePickerButton />
     </div>
   </div>
+  <NuxtLoadingIndicator color="var(--color-primary)" :height="2" :throttle="0" class="mt-15.5"/>
+
 </template>
 
 <script setup lang="ts">

--- a/frontend/NuxtPort/linux-ricing-guide/components/ThemePickerButton.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/ThemePickerButton.vue
@@ -5,9 +5,12 @@
       <ul tabindex="0" class="dropdown-content bg-base-300 rounded-box z-1 p-2 shadow-2xl w-min"
         style="max-height: 15rem; overflow-y: auto;">
         <li v-for="theme in themes" :key="theme">
-          <input type="radio" name="theme-dropdown"
-            class="theme-controller btn btn-sm btn-block btn-ghost justify-start m-1 p-1 text-center"
-            :aria-label="toHeaderCase(theme)" :value="theme" v-model="selectedTheme" />
+
+          <div class="btn btn-sm btn-block btn-ghost justify-start m-1 p-1 text-center" @click="setTheme(theme)">
+            <DynamicIcon :names="{default: 'paintbrush'}" />
+            <p>{{toHeaderCase(theme)}}</p>
+            <input type="radio" name="theme-dropdown" class="theme-controller hidden" :value="theme" />
+          </div>
         </li>
       </ul>
     </div>
@@ -15,21 +18,35 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue';
 import { toHeaderCase } from 'assets/utils/caseUtils'
+
+onMounted(() => {
+  const selectedTheme = localStorage.getItem('selectedTheme') || 'default';
+  setTheme(selectedTheme);
+})
 
 const themes = [
   'default', 'light', 'dark', 'cupcake', 'bumblebee', 'emerald', 'corporate', 'synthwave', 'retro', 'valentine', 'halloween', 'garden', 'forest', 'aqua', 'lofi', 'pastel', 'fantasy', 'dracula', 'cmyk', 'autumn', 'acid', 'lemonade', 'night', 'coffee', 'winter', 'dim', 'nord', 'sunset', 'caramellatte', 'abyss', 'silk'
 ]
 
-const selectedTheme = ref(
-  import.meta.client ? localStorage.getItem('selectedTheme') || 'default' : 'default'
-);
+function setTheme(theme: string) {
+  localStorage.setItem('selectedTheme', theme);
 
-watch(selectedTheme, (newTheme) => {
-  if (import.meta.client) {
-    localStorage.setItem('selectedTheme', newTheme);
-    document.documentElement.setAttribute('data-theme', newTheme);
-  }
-});
+  const radios = document.querySelectorAll('.theme-controller');
+
+  radios.forEach((radioI) => {
+    let radio = radioI as HTMLInputElement;
+    if (radio.getAttribute('value') === theme) {
+      radio.checked = true;
+      // btn-primary
+      radio.parentElement!.classList.add('btn-primary');
+      radio.parentElement!.classList.remove('btn-ghost');
+    } else {
+      radio.checked = false;
+
+      radio.parentElement!.classList.remove('btn-primary');
+      radio.parentElement!.classList.add('btn-ghost');
+    }
+  });
+}
 </script>

--- a/frontend/NuxtPort/linux-ricing-guide/layouts/default.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/layouts/default.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="background">
     <AppNavbar />
-    <NuxtLoadingIndicator color="var(--color-primary)" :height="3" :throttle="0" />
     <div>
       <slot />
     </div>


### PR DESCRIPTION
This pull request includes changes to the `AppNavbar.vue` and `default.vue` components in the `frontend/NuxtPort/linux-ricing-guide` directory. The main focus of the changes is to adjust the layout and improve the loading indicator's placement.

Changes to layout and loading indicator:

* [`frontend/NuxtPort/linux-ricing-guide/components/AppNavbar.vue`](diffhunk://#diff-1c1bb38d90b1e1d62a63fa3a7b43aa1e1a2ad58e6c08ffc711f5e154060c8eaeL2-R2): Modified the navbar to have a fixed height of 16 units and added a `NuxtLoadingIndicator` with specific styling properties. [[1]](diffhunk://#diff-1c1bb38d90b1e1d62a63fa3a7b43aa1e1a2ad58e6c08ffc711f5e154060c8eaeL2-R2) [[2]](diffhunk://#diff-1c1bb38d90b1e1d62a63fa3a7b43aa1e1a2ad58e6c08ffc711f5e154060c8eaeR54-R55)
* [`frontend/NuxtPort/linux-ricing-guide/layouts/default.vue`](diffhunk://#diff-df8c9ca1f062df9c87b91b25b844b32aba8bb96a75ec39aaad347f821c2b8829L4): Removed the `NuxtLoadingIndicator` from the default layout, as it has been moved to the `AppNavbar.vue` component.