### PR TITLE
Search bar changes, Title to page

### DIFF
--- a/frontend/NuxtPort/linux-ricing-guide/components/Search.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/components/Search.vue
@@ -4,11 +4,11 @@
     <div class="relative flex items-center">
       <DynamicIcon :names="{ 'default': 'magnifying-glass', 'mdi': 'search' }" :size="20" />
       <input v-model="searchQuery" @input="debouncedSearch" @focus="showResults = true"
-        @blur="setTimeout(() => { showResults = false }, 200)" placeholder="Search..." type="search"
+        @blur="setTimeout(() => { showResults = false }, 200)" placeholder="Search..." type="text"
         class="w-full py-2 px-4 pr-10" />
       <!-- Loading Spinner -->
       <div v-if="loading"
-        class="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 border-2 border-gray-400 border-t-white rounded-full animate-spin">
+        class="absolute right-3 loading loading-dots loading-xs">
       </div>
     </div>
 
@@ -24,7 +24,8 @@
 
     <!-- No Results Message -->
     <div v-if="showResults && searchQuery.length >= 2 && !loading && results.length === 0"
-      class="absolute z-50 w-full mt-2 p-4 shadow-lg bg-amber-900 rounded-md text-base-600">
+      class="absolute z-50 w-full mt-2 p-4 shadow-lg bg-base-100 rounded-md text-base-600 flex items-center">
+      <DynamicIcon :names="{ 'default': 'triangle-exclamation'}" :size="16" class="mr-2"/>
       No results found for "{{ searchQuery }}"
     </div>
 

--- a/frontend/NuxtPort/linux-ricing-guide/layouts/default.vue
+++ b/frontend/NuxtPort/linux-ricing-guide/layouts/default.vue
@@ -14,3 +14,22 @@
   background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='-10 -10 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23939393' fill-opacity='0.16'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }
 </style>
+
+<script setup lang="ts">
+import {useRoute} from "#vue-router";
+import {ref, watch} from "vue";
+import {toHeaderCase} from "assets/utils/caseUtils";
+
+const route = useRoute()
+
+onMounted(() => {
+  watch(route, updateRouteParts, { immediate: true });
+})
+
+const updateRouteParts = () => {
+  document.title = toHeaderCase((route.name === "index" ? "home" : route.name!).toString())
+};
+
+
+
+</script>

--- a/frontend/NuxtPort/linux-ricing-guide/server/api/search.ts
+++ b/frontend/NuxtPort/linux-ricing-guide/server/api/search.ts
@@ -2,6 +2,7 @@ import { H3Event } from 'h3'
 import { resolve } from 'path'
 import { readFile } from 'fs/promises'
 import { parse } from '@vue/compiler-dom'
+import {toHeaderCase} from "assets/utils/caseUtils";
 
 export default defineEventHandler(async (event: H3Event) => {
   const query = getQuery(event).q?.toString()?.toLowerCase()
@@ -15,6 +16,7 @@ export default defineEventHandler(async (event: H3Event) => {
 
   const pages = await getPageRoutes()
   const results = []
+
   
   for (const page of pages) {
     try {
@@ -22,7 +24,7 @@ export default defineEventHandler(async (event: H3Event) => {
       if (content.toLowerCase().includes(query)) {
         results.push({
           path: page.routePath,
-          title: extractPageTitle(content) || page.routePath
+          title: toHeaderCase(page.routePath === "" ? "home" : page.routePath)
         })
       }
     } catch (error) {
@@ -52,7 +54,7 @@ async function getPageRoutes(): Promise<PageInfo[]> {
 
   return pageFiles.map(file => ({
     routePath: file
-      .replace(/^\/?index\.vue$/, '/')
+      .replace(/^\/?index\.vue$/, '')
       .replace(/\.vue$/, '')
       .replace(/\/index$/, '')
       .replace(/\[([^\]]+)\]/g, ':$1'),


### PR DESCRIPTION
This pull request includes several updates to the `frontend/NuxtPort/linux-ricing-guide` project, focusing on improving the search functionality, user experience, and code maintainability. The most important changes include modifications to the search component, updates to the page route handling, and enhancements to the default layout.

### Improvements to Search Component:

* [`frontend/NuxtPort/linux-ricing-guide/components/Search.vue`](diffhunk://#diff-02649f79084882774a501ec1c33f7431a6ac49206d5a42f7626c7126d17c2e8aL7-R11): Changed the input type from `search` to `text` and updated the loading spinner to use a different class for better styling.
* [`frontend/NuxtPort/linux-ricing-guide/components/Search.vue`](diffhunk://#diff-02649f79084882774a501ec1c33f7431a6ac49206d5a42f7626c7126d17c2e8aL27-R28): Added an icon to the "No Results" message for better user feedback.

### Enhancements to Page Route Handling:

* [`frontend/NuxtPort/linux-ricing-guide/server/api/search.ts`](diffhunk://#diff-238a559f992382c0d5f4746d9f4c6a3bd05ec4a10fa31dca85b028a6dee5d366R5): Added `toHeaderCase` utility to format route paths and titles, ensuring consistent title casing in search results. [[1]](diffhunk://#diff-238a559f992382c0d5f4746d9f4c6a3bd05ec4a10fa31dca85b028a6dee5d366R5) [[2]](diffhunk://#diff-238a559f992382c0d5f4746d9f4c6a3bd05ec4a10fa31dca85b028a6dee5d366R20-R27)
* [`frontend/NuxtPort/linux-ricing-guide/server/api/search.ts`](diffhunk://#diff-238a559f992382c0d5f4746d9f4c6a3bd05ec4a10fa31dca85b028a6dee5d366L55-R57): Modified the route path handling to remove the leading slash and handle index routes correctly.

### Updates to Default Layout:

* [`frontend/NuxtPort/linux-ricing-guide/layouts/default.vue`](diffhunk://#diff-df8c9ca1f062df9c87b91b25b844b32aba8bb96a75ec39aaad347f821c2b8829R17-R35): Added script to update the document title based on the current route, improving the user experience by reflecting the active page in the browser tab.